### PR TITLE
Making code more generic by using Entity instead of CowEntity

### DIFF
--- a/src/main/java/org/sdoaj/catapult/FallingBlockEventHandler.java
+++ b/src/main/java/org/sdoaj/catapult/FallingBlockEventHandler.java
@@ -1,6 +1,7 @@
 package org.sdoaj.catapult;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityFallingBlock;
 import net.minecraft.entity.passive.EntityCow;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
@@ -9,21 +10,21 @@ public class FallingBlockEventHandler {
 	
 	@SubscribeEvent
 	public void immobilizeFallingBlock(LivingUpdateEvent event) {
-		if (!(event.entity instanceof EntityCow)) {
+		if (!(event.entity instanceof Entity)) {
 			return;
 		}
 		
-		EntityCow cow = (EntityCow) event.entity;
+		final Entity entity = (Entity) event.entity;
 		
-		if (!cow.isRiding()) {
+		if (!entity.isRiding()) {
 			return;
 		}
 		
-		if (!(cow.ridingEntity instanceof EntityFallingBlock)) {
+		if (!(entity.ridingEntity instanceof EntityFallingBlock)) {
 			return;
 		}
 		
-		EntityFallingBlock block = (EntityFallingBlock) cow.ridingEntity;
+		final EntityFallingBlock block = (EntityFallingBlock) entity.ridingEntity;
 		
 		if (!block.onGround) {
 			return;


### PR DESCRIPTION
There was no need to cast to `EntityCow`, `Entity` was enough as it had all the methods you were using. In general it's always best to take the highest possible interface, i.e. the least specific.
For example when you create a list variable you would use `List` instead of `ArrayList`